### PR TITLE
Address Issue #331 Typo in docstring for StreamDecryptor

### DIFF
--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -734,7 +734,7 @@ class DecryptorConfig(_ClientConfig):
 
 
 class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-attributes
-    """Provides a streaming encryptor for encrypting a stream source.
+    """Provides a streaming decryptor for decrypting a stream source.
     Behaves as a standard file-like object.
 
     .. note::


### PR DESCRIPTION
Address Issue #331 Typo in docstring for StreamDecryptor by correctly referring to the classes actions as decryption as compared to encryption.

*Issue #, if available:* #331

*Description of changes:* Replace incorrect encryption references with correct decryption references


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

